### PR TITLE
I think this makes a little more sense

### DIFF
--- a/2020/3/go.mod
+++ b/2020/3/go.mod
@@ -1,3 +1,0 @@
-module github.com/cshoe/advent-of-code/2020/3
-
-go 1.15

--- a/2020/3/go.sum
+++ b/2020/3/go.sum
@@ -1,1 +1,0 @@
-github.com/cshoe/advent-of-code v0.0.0-20201203010736-7b6e1d9509b6 h1:eJHOfjkCaoc3CQl1px8wkl9tVTcNHwEW2ZjTKi/lY8Q=

--- a/2020/go.mod
+++ b/2020/go.mod
@@ -1,0 +1,3 @@
+module github.com/cshoe/advent-of-code/2020
+
+go 1.15


### PR DESCRIPTION
Moving the go.mod file up to the 2020 directory to treat the whole year as a module.